### PR TITLE
Create blockheaders get controller router

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-user = "doadmin"
-host = 'db-postgresql-nyc3-17024-do-user-11762763-0.b.db.ondigitalocean.com'
-port = 25060
-database = 'blockchain'
-password = "AVNS_xs9j15r-uKmQqfU-sms"

--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+user = "doadmin"
+host = 'db-postgresql-nyc3-17024-do-user-11762763-0.b.db.ondigitalocean.com'
+port = 25060
+database = 'blockchain'
+password = "AVNS_xs9j15r-uKmQqfU-sms"

--- a/api/controllers/blockheaders.ts
+++ b/api/controllers/blockheaders.ts
@@ -12,6 +12,7 @@ interface Post {
   body: String;
 }
 
+// helper function that returns maximum height of bitcoin blockchain (used in couple controllers)
 const currMaxBlock = async () => {
   let maxblock_query = `
     SELECT
@@ -26,6 +27,7 @@ const currMaxBlock = async () => {
   return blockHeight;
 }
 
+// get maximum block height of bitcoin blockchain
 const getMaxBlockHeight = async (req: Request, res: Response, next: NextFunction) => {
   let maxCurrentBlockHeight: any[] = await currMaxBlock();
 
@@ -40,19 +42,22 @@ const getBlocks = async (req: Request, res: Response, next: NextFunction) => {
   let maxCurrentBlockHeight: any[] = await currMaxBlock();
   let sHeightDefault: number = Number(maxCurrentBlockHeight[0]['height']);
 
-  // query params
+  // Set query params
   let hend = Number(req.query.hend) || sHeightDefault; // If no hend - use the current max block height
   let hstart = Number(req.query.hstart) || hend - 25; // If no start - use hend - 25
 
   // query to get all block headers ordered by height desc
-  // Using encode(hash, 'escape') allows to turn bytea:
+  // Using encode(hash, 'escape') allows to turn bytea into text:
     // \\x30303030303030303030303030303030303030383438386361636339323863353635366431333263353632353130623734633934626136316235363236366566
     // 00000000000000000008488cacc928c5656d132c562510b74c94ba61b56266ef
+  // However, depending on how we are storing hash - this may not be needed
   const blockheader_query = `
     SELECT
+      /*  hash is stored as bytea, escape turns it into a string instead of getting the hash as raw bytes */
       encode(hash, 'escape')::text AS hash
       , height
       , version
+      /*  hash is stored as bytea, escape turns it into a string instead of getting the hash as raw bytes */
       , encode(prev_hash, 'escape')::text AS prev_hash
       , timestamp
       , bits
@@ -83,14 +88,17 @@ const getBlock = async (req: Request, res: Response, next: NextFunction) => {
   let id: string = String(req.params.id);
 
   // query to get blockheader data
+  // using encode(hash, 'escape') allows to turn bytea into text:
+    // \\x30303030303030303030303030303030303030383438386361636339323863353635366431333263353632353130623734633934626136316235363236366566
+    // 00000000000000000008488cacc928c5656d132c562510b74c94ba61b56266ef
   const blockheader_query = `
   SELECT
     /*  hash is stored as bytea, escape turns it into a string instead of getting the hash as raw bytes */
-    hash::text AS hash
+    encode(hash, 'escape')::text AS hash
     , height
     , version
     /*  hash is stored as bytea, escape turns it into a string instead of getting the hash as raw bytes */
-    , hash::text AS prev_hash
+    , encode(prev_hash, 'escape')::text AS prev_hash
     , timestamp
     , bits
     , nonce

--- a/api/routes/blockheaders.ts
+++ b/api/routes/blockheaders.ts
@@ -2,8 +2,10 @@ import express from "express";
 import controller from "../controllers/blockheaders";
 const router = express.Router();
 
+router.get("/blockheaders", controller.getBlocks);
+router.get("/blockheaders/height", controller.getMaxBlockHeight);
 router.get('/blockheaders/:id', controller.getBlock);
-// router.get("/blockheaders", controller.getBlockHeader);
+
 // router.get("/blockheaders/:id", controller.getBlockHeader);
 // router.put("/blockheaders/:id", controller.updateBlockHeader);
 // router.delete("/blockheaders/:id", controller.deleteBlockHeader);


### PR DESCRIPTION

* Created routes & controller for "/blockheaders" (retrieves multiple block headers - if no query parameters - defaults to retrieving 25 most recent blocks)
* Created routes & controller for "/blockheaders/height" (retrieves the max block height)
* Went back to using `encode` with `escape` to convert:

Bytea:    \\x30303030303030303030303030303030303030383438386361636339323863353635366431333263353632353130623734633934626136316235363236366566

to

String hash:

00000000000000000008488cacc928c5656d132c562510b74c94ba61b56266ef