### PR TITLE
Additional features on block page

### DIFF
--- a/api/controllers/blockheaders.ts
+++ b/api/controllers/blockheaders.ts
@@ -2,8 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import axios, { AxiosResponse } from "axios";
 import pool from "../database/db";
 import { QueryResult } from "pg";
-
-// TODO: switch to BlockHeadersController
+import moment from 'moment';
 
 // helper function that returns maximum height of bitcoin blockchain (used in couple controllers)
 const currMaxBlock = async () => {
@@ -47,13 +46,13 @@ const getBlocks = async (req: Request, res: Response, next: NextFunction) => {
 
   // To avoid pull hundreds of thousands of blocks if start begins at 0 with no hend query parameter
   if (Number.isInteger(hstart) && Number.isNaN(hend)) {
-    hend = hstart + 25;
+    hend = hstart + 35;
   } else if (Number.isNaN(hend) && Number.isNaN(hstart)) {
     hend = sHeightDefault;
   }
 
   if (Number.isNaN(hstart)) {
-    hstart = hend - 25;
+    hstart = hend - 35;
   }
 
   // query to get all block headers ordered by height desc
@@ -101,17 +100,55 @@ const getBlock = async (req: Request, res: Response, next: NextFunction) => {
     , height
     , version
     , prev_block_hash AS prev_hash
+    , merkle_root
     , timestamp
     , bits
     , nonce
     , size
     , weight
     , num_tx
+    , difficulty
     , confirmations
   FROM
     bitcoin.block_headers
   WHERE
     hash = '${id}'
+  `;
+
+  // get data for a specific block header
+  let pgResult: QueryResult<any> = await pool.query(blockheader_query);
+  let blockHeaderData: any[] = pgResult.rows;
+
+  return res.status(200).json({
+    message: blockHeaderData,
+  });
+};
+
+// getting a single block by height
+const getBlockByHeight = async (req: Request, res: Response, next: NextFunction) => {
+  // get the block hash from the req
+  let height: number = Number(req.params.height);
+
+  // query to get blockheader data
+  const blockheader_query = `
+  SELECT
+    hash AS hash
+    , height
+    , version
+    , prev_block_hash AS prev_hash
+    , merkle_root
+    , timestamp
+    , bits
+    , nonce
+    , size
+    , weight
+    , num_tx
+    , difficulty
+    , confirmations
+  FROM
+    bitcoin.block_headers
+  WHERE
+    height = ${height}
   `;
 
   // get data for a specific block header
@@ -139,4 +176,57 @@ const getBlockTxs = async (req: Request, res: Response, next: NextFunction) => {
   });
 };
 
-export default { getBlocks, getMaxBlockHeight, getBlock, getBlockTxs };
+const postBlockByHeights = async (req: Request, res: Response, next: NextFunction) => {
+  let { startHeight, endHeight } = req.query;
+  try {
+    if (startHeight && endHeight) {
+      let startHeightNum = Number(startHeight);
+      let endHeightNum = Number(endHeight);
+      for (let idx = startHeightNum + 1; idx < endHeightNum; idx++) {
+        // get hash of the given height
+        let heightResponse: AxiosResponse = await axios.get(
+          `https://blockstream.info/api/block-height/${idx}`
+        );
+        let hashData = heightResponse.data;
+        let blockResponse: AxiosResponse = await axios.get(
+          `https://blockstream.info/api/block/${hashData}`
+        );
+
+        // get the block information based on hash derived from height
+        let block: any = blockResponse.data;
+        let insert_query = `INSERT INTO bitcoin.block_headers
+              (hash, height, version, prev_block_hash, merkle_root, timestamp, median_time
+                , bits, nonce, size, weight, num_tx, difficulty, confirmations)
+            VALUES
+              ('${block['id']}', ${block['height']}, ${block['version']}, '${block['previousblockhash']}'
+              , '${block['merkle_root']}', '${moment.unix(block['timestamp']).format('YYYY-MM-DD HH:mm:ss')}', ${block['mediantime']}
+              , '${block['bits'].toString(16)}', ${block['nonce']}, ${block['size']}, ${block['weight']}
+              , ${block['tx_count']}, ${block['difficulty']}, NULL)`;
+
+        let error;
+        pool.query(
+          insert_query, async (err: any, res: any) => {
+            if (err) {
+              error = await err;
+            }
+          }
+        );
+
+        if (error) break;
+        console.log(error);
+      }
+    }
+  } catch (err) {
+    console.log(err);
+    res.status(500).json({ msg: "Something bad has occurred." });;
+  }
+}
+
+export default {
+  getBlocks,
+  getMaxBlockHeight,
+  getBlock,
+  getBlockTxs,
+  getBlockByHeight,
+  postBlockByHeights
+};

--- a/api/controllers/dashboard.ts
+++ b/api/controllers/dashboard.ts
@@ -23,8 +23,6 @@ export const getTxsOverTime = async (
     group by 1 order by 1 asc;
   `;
 
-  console.log(txs_over_time_query);
-
   // get data for a specific block header
   let pgResult: QueryResult<any> = await pool.query(txs_over_time_query);
   let txsOverTime: any[] = pgResult.rows;

--- a/api/routes/blockheaders.ts
+++ b/api/routes/blockheaders.ts
@@ -3,8 +3,10 @@ import controller from "../controllers/blockheaders";
 const router = express.Router();
 
 router.get("/blockheaders", controller.getBlocks);
+router.post("/blockheaders", controller.postBlockByHeights);
 router.get("/blockheaders/height", controller.getMaxBlockHeight);
-router.get('/blockheaders/:id', controller.getBlock);
+router.get('/blockheaders/:height', controller.getBlockByHeight);
+router.get('/blockheaders/hash/:id', controller.getBlockByHeight);
 router.get('/blockheaders/:id/txs', controller.getBlockTxs);
 
 export = router;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,9 +8,10 @@ const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
-  <React.StrictMode>
+  // Disabled strict mode because it runs useEffect twice on every load (i.e. it leads to duplicate insert error from pg since I am trying to insert the same block twice each page load)
+  // <React.StrictMode>
     <App />
-  </React.StrictMode>
+  // </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/client/src/pages/BlocksPage/BlockHeaderInfoComponent.tsx
+++ b/client/src/pages/BlocksPage/BlockHeaderInfoComponent.tsx
@@ -4,12 +4,14 @@ import {
   TableRow,
   TableBody,
   TableCell,
+  Grid,
   TableContainer,
   Paper,
   Typography,
 } from "@mui/material";
 import React from "react";
 import { BlockHeader } from "./BlocksTypes";
+import moment from 'moment';
 
 export interface IProps {
   block: BlockHeader | undefined;
@@ -17,9 +19,12 @@ export interface IProps {
 
 const BlockHeaderInfoComponent: React.FC<IProps> = ({ block }) => {
   // Additional block information parsing for displaying cleaned key in the table component
-
   return (
+    <React.Fragment>
     <Card sx={{ m: 2 }}>
+      <Typography variant="h5" sx={{'ml': '1rem', 'mt': '1rem'}}>
+        Block Header Information
+      </Typography>
       <TableContainer component={Paper}>
         <Table sx={{ minWidth: 650 }} aria-label="simple table">
           {block ? (
@@ -39,94 +44,20 @@ const BlockHeaderInfoComponent: React.FC<IProps> = ({ block }) => {
                   {block["hash"]}
                 </TableCell>
               </TableRow>
-              <TableRow>
-                <TableCell component="th" scope="row">
+              <TableRow sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
+                <TableCell component="th" scope="row" align="left">
                   Merkle Root:
                 </TableCell>
-                <TableCell component="th" scope="row" />
+                <TableCell align="left"/>
                 <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "right" }}
+                  align="right"
                 >
                   {block["merkle_root"]}
                 </TableCell>
               </TableRow>
-              <TableRow>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "left" }}
-                >
-                  Timestamp: {block["timestamp"]}
-                </TableCell>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "right" }}
-                >
-                  Version: {block["version"]}
-                </TableCell>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "right" }}
-                >
-                  Difficulty: {block["difficulty"]}
-                </TableCell>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "right" }}
-                ></TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "left" }}
-                >
-                  Difficulty: {block["difficulty"]}
-                </TableCell>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "right" }}
-                >
-                  Bits: {block["bits"]}
-                </TableCell>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "right" }}
-                >
-                  Nonce: {block["nonce"]}
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "left" }}
-                >
-                  Size: {block["size"]}
-                </TableCell>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "right" }}
-                >
-                  Weight: {block["weight"]}
-                </TableCell>
-                <TableCell
-                  component="th"
-                  scope="row"
-                  sx={{ textAlign: "right" }}
-                >
-                  Confirmations: {block["confirmations"]}
-                </TableCell>
-              </TableRow>
             </TableBody>
+
+
           ) : (
             <Typography
               variant="h5"
@@ -134,12 +65,117 @@ const BlockHeaderInfoComponent: React.FC<IProps> = ({ block }) => {
               alignItems="center"
               sx={{ padding: "2rem" }}
             >
-              Please select a block from the left sidebar.
+              Loading...
             </Typography>
           )}
         </Table>
+
+
+
       </TableContainer>
     </Card>
+    {block ? (
+      <Grid container spacing={1}>
+        <Grid item xs={6}>
+          <Card sx={{ m: 2,  }}>
+            <TableContainer component={Paper}>
+              <Table sx={{ minWidth: 350 }}>
+                <TableBody>
+                  <TableRow>
+                      <TableCell component="th" scope="row">
+                        Height
+                      </TableCell>
+                      <TableCell align="right">
+                        {block["height"]}
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell component="th" scope="row">
+                        Timestamp
+                      </TableCell>
+                      <TableCell  align="right">
+                        {moment(block["timestamp"]).format("MM/DD/YYYY h:mm:ss a")}
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell component="th" scope="row">
+                        Version
+                      </TableCell>
+                      <TableCell align="right">
+                        {block["version"]}
+                      </TableCell>
+                    </TableRow>
+
+                    <TableRow>
+                      <TableCell component="th" scope="row">
+                        Difficulty
+                      </TableCell>
+                      <TableCell align="right">
+                        {block["difficulty"]}
+                      </TableCell>
+                    </TableRow>
+                    <TableRow sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
+                      <TableCell component="th" scope="row">
+                        Transactions
+                      </TableCell>
+                      <TableCell align="right">
+                        {block["num_tx"]}
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+              </Table>
+            </TableContainer>
+          </Card>
+        </Grid>
+        <Grid item xs={6}>
+          <Card sx={{ m: 2 }}>
+            <TableContainer component={Paper}>
+              <Table sx={{ minWidth: 350 }}>
+                <TableBody>
+                  <TableRow>
+                    <TableCell component="th" scope="row">
+                      Bits
+                    </TableCell>
+                    <TableCell  align="right">
+                      {block["bits"]}
+                    </TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell component="th" scope="row">
+                      Nonce
+                    </TableCell>
+                    <TableCell align="right">
+                      {block["nonce"]}
+                    </TableCell>
+                  </TableRow>
+
+                  <TableRow>
+                    <TableCell component="th" scope="row">
+                      Size
+                    </TableCell>
+                    <TableCell align="right">
+                      {block["size"]}
+                    </TableCell>
+                  </TableRow>
+                  <TableRow sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
+                    <TableCell component="th" scope="row">
+                      Weight
+                    </TableCell>
+                    <TableCell align="right">
+                      {block["weight"]}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </TableContainer>
+            </Card>
+          </Grid>
+        </Grid>) : null}
+
+    </React.Fragment>
   );
 };
 

--- a/client/src/pages/BlocksPage/BlockTxsComponent.tsx
+++ b/client/src/pages/BlocksPage/BlockTxsComponent.tsx
@@ -1,6 +1,5 @@
-import { List, ListItem, Typography } from "@mui/material";
+import { List, Grid, ListItem, Typography } from "@mui/material";
 import React from "react";
-import { Link } from "react-router-dom";
 import CollapsableTransaction from "./CollapsableTransactionComponent";
 
 export interface IProps {
@@ -10,13 +9,15 @@ export interface IProps {
 
 const BlockTxsComponent: React.FC<IProps> = ({ txids, page }) => {
   return (
-    <div>
+    <Grid sx={{position: 'sticky',
+    top: '0'}}>
       {txids.length ? (
         <List
           sx={{
-            height: "50vh",
+            height: "60vh",
             bgcolor: "background.paper",
             overflow: "auto",
+            mt: '1rem',
           }}
         >
           {txids.map((txid, index) => {
@@ -32,10 +33,10 @@ const BlockTxsComponent: React.FC<IProps> = ({ txids, page }) => {
         </List>
       ) : (
         <Typography variant="body1" align="center">
-          none
+          Loading...
         </Typography>
       )}
-    </div>
+    </Grid>
   );
 };
 

--- a/client/src/pages/BlocksPage/BlocksListComponent.tsx
+++ b/client/src/pages/BlocksPage/BlocksListComponent.tsx
@@ -3,7 +3,6 @@ import { Dispatch, SetStateAction } from "react";
 import blockImg from "./block.png";
 import { BlockHeader } from "./BlocksTypes";
 import {
-  Avatar,
   List,
   ListItem,
   ListItemAvatar,
@@ -11,16 +10,7 @@ import {
   ListItemText,
   Box,
 } from "@mui/material";
-
-// function createData(
-//   name: string,
-//   calories: number,
-//   fat: number,
-//   carbs: number,
-//   protein: number
-// ) {
-//   return { name, calories, fat, carbs, protein };
-// }
+import moment from 'moment';
 
 export interface IProps {
   block: BlockHeader | undefined;
@@ -44,14 +34,16 @@ const BlocksListComponent: React.FC<IProps> = ({ block, setBlock }) => {
   return (
     <List
       sx={{
-        height: "87vh",
+        height: "100vh",
         maxWidth: 360,
         bgcolor: "background.paper",
         overflow: "auto",
+        position: 'sticky',
+        top: '.25rem',
       }}
     >
       {blockheaders ? (
-        <div>
+        <React.Fragment>
           {blockheaders.map((blockheader) => (
             <ListItem
               onClick={() => setBlock(blockheader)}
@@ -77,11 +69,11 @@ const BlocksListComponent: React.FC<IProps> = ({ block, setBlock }) => {
               </ListItemAvatar>
               <ListItemText
                 primary={blockheader.height}
-                secondary={blockheader.timestamp}
+                secondary={moment(blockheader.timestamp).format("YYYY-MM-DD HH:mm:ss")}
               />
             </ListItem>
           ))}
-        </div>
+        </React.Fragment>
       ) : (
         <Typography variant="body1" align="center">
           Loading...

--- a/client/src/pages/BlocksPage/BlocksTypes.tsx
+++ b/client/src/pages/BlocksPage/BlocksTypes.tsx
@@ -21,6 +21,7 @@ export interface Transaction {
   size: number;
   weight: number;
   fee: number;
+  is_coinbase: boolean;
   status: Status;
 }
 

--- a/client/src/pages/BlocksPage/CollapsableTransactionComponent.tsx
+++ b/client/src/pages/BlocksPage/CollapsableTransactionComponent.tsx
@@ -6,6 +6,7 @@ import Typography from "@mui/material/Typography";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Link } from "react-router-dom";
 import { Transaction } from "./BlocksTypes";
+import TransactionHeaderInfoComponent from "./TransactionHeaderInfoComponent";
 
 export interface IProps {
   index: number;
@@ -35,19 +36,16 @@ const CollapsableTransaction: React.FC<IProps> = ({ index, txid }) => {
           id="panel1a-header"
         >
           <Typography>
-            {index} :{" "}
             <Link
               to={`/tx/${txid}`}
-              style={{ textDecoration: "none", color: "white" }}
+              style={{ textDecoration: "none", color: '#00ccff' }}
             >
               {txid}
             </Link>
           </Typography>
         </AccordionSummary>
         <AccordionDetails>
-          <Typography>
-            {tx ? JSON.stringify(tx, null, 2) : "Loading..."}
-          </Typography>
+          {tx ? <TransactionHeaderInfoComponent transaction={tx}/> : <Typography variant="h5">Loading...</Typography>}
         </AccordionDetails>
       </Accordion>
     </div>

--- a/client/src/pages/BlocksPage/TransactionHeaderInfoComponent.tsx
+++ b/client/src/pages/BlocksPage/TransactionHeaderInfoComponent.tsx
@@ -1,0 +1,94 @@
+import {
+  Card,
+  Table,
+  TableRow,
+  TableBody,
+  TableCell,
+  TableContainer,
+  Paper,
+  Typography,
+} from "@mui/material";
+import { Transaction } from "./BlocksTypes";
+import React from 'react';
+
+export interface IProps {
+  transaction: Transaction | undefined;
+}
+
+const TransactionHeaderInfoComponent: React.FC<IProps> = ({ transaction }) => {
+
+  // sx={{backgroundColor: '#111316'}}
+  // sx={{backgroundColor: '#24273d'}}
+  // #15181b
+  // #121212
+
+  return (
+    <React.Fragment>
+      <Typography variant="h6" align="left" sx={{opacity: .9, 'mb': '.25rem'}}>
+        Transaction Headers
+      </Typography>
+      <Card sx={{backgroundColor: '#24273d', opacity: .8}}>
+        <TableContainer component={Paper}>
+          <Table sx={{ minWidth: 350, backgroundColor: '#15191d'}} aria-label="simple table">
+            {transaction ? (
+              <TableBody>
+                <TableRow
+                  sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+                >
+                  <TableCell component="th" scope="row">
+                    Version
+                  </TableCell>
+                  <TableCell  align="right">
+                    {transaction['version']}
+                  </TableCell>
+                </TableRow>
+                <TableRow
+                  sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+                >
+                  <TableCell component="th" scope="row">
+                    Locktime
+                  </TableCell>
+                  <TableCell  align="right">
+                    {transaction['locktime']}
+                  </TableCell>
+                </TableRow>
+                <TableRow
+                  sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+                >
+                  <TableCell component="th" scope="row">
+                    Size
+                  </TableCell>
+                  <TableCell  align="right">
+                    {transaction['size']}
+                  </TableCell>
+                </TableRow>
+                <TableRow
+                  sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+                >
+                  <TableCell component="th" scope="row">
+                    Weight
+                  </TableCell>
+                  <TableCell  align="right">
+                    {transaction['weight']}
+                  </TableCell>
+                </TableRow>
+                <TableRow
+                  sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+                >
+                  <TableCell component="th" scope="row">
+                    Fee
+                  </TableCell>
+                  <TableCell  align="right">
+                    {transaction['fee']}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            ) : null }
+          </Table>
+        </TableContainer>
+      </Card>
+    </React.Fragment>
+  )
+}
+
+export default TransactionHeaderInfoComponent;


### PR DESCRIPTION
* Make the list stick to content as users scroll (Done)
* Set on initial load to use the current max block from db (Done)
* Create new display tables for better organizing block information (Done)
* Add a table to tx details in block headers page
* Additional layer of logic on block page: 1. if missing data hit espolora and add to database; 2. default to show last block (not No blocks selected)
* Maybe a vin, vout display? Talk to Kody about this